### PR TITLE
Make services user-agnostic for any username and directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,17 +112,32 @@ The application includes Raspberry Pi specific functionality:
 
 ### Raspberry Pi Setup
 
-The application is designed to run on Raspberry Pi with the user directory at `/home/weber/pi_air`.
+The application is designed to run on any Raspberry Pi with automatic user and path detection.
 
 **Prerequisites:**
 - Python 3.7+
 - PMS7003 air quality sensor (connected via serial)
 - Virtual environment setup
 
-**Installation paths:**
-- Project directory: `/home/weber/pi_air`
-- Virtual environment: `/home/weber/pi_air/venv`
-- Service user: `weber`
+### Automatic Installation
+
+The installation script automatically detects:
+- Current user (works with any username, not just 'pi' or 'weber')
+- Project directory location
+- User's primary group
+- Virtual environment path
+
+**Installation Process:**
+```bash
+# From the project directory
+sudo ./scripts/install_service.sh
+```
+
+The script will:
+1. Detect your current user and project paths
+2. Verify virtual environment exists
+3. Generate service files with correct paths
+4. Install and start systemd services
 
 ### Systemd Services
 
@@ -131,10 +146,11 @@ Two systemd services handle automatic startup:
 1. **pimonitor.service** - Flask web application
 2. **air-quality-monitor.service** - PMS7003 sensor data collection
 
-Service files are located in `/etc/systemd/system/` and configured to:
+Service files are dynamically generated and configured to:
 - Start automatically on boot
 - Restart on failure
-- Run as user `weber`
+- Run as the detected user
+- Use the detected project directory
 - Log to systemd journal
 
 ## Important Considerations

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ This script will:
 - Create a Python virtual environment
 - Install all dependencies
 - Set up the SQLite database
-- Create systemd services
+- Create systemd services with automatic user/path detection
 - Configure services to start on boot
 
 ### Manual Setup
@@ -86,11 +86,19 @@ pip install -r requirements.txt
 python -c "from src.database import init_db; init_db()"
 ```
 
-4. Install systemd services:
+4. Install systemd services (automatically detects user and paths):
 ```bash
 sudo chmod +x scripts/install_service.sh
 sudo ./scripts/install_service.sh
 ```
+
+The installation script automatically detects:
+- Your current username (works with any user, not just 'pi')
+- Project directory location
+- User's primary group
+- Virtual environment path
+
+This ensures the services work regardless of your username or installation directory.
 
 ## Usage
 
@@ -168,7 +176,7 @@ git push origin main
 
 3. Pull changes on your Pi:
 ```bash
-cd ~/pi_air
+cd /path/to/your/pi_air  # Or wherever you installed the project
 git pull origin main
 ```
 
@@ -182,7 +190,7 @@ sudo systemctl restart air-quality-monitor.service
 
 Run the PMS7003 sensor test:
 ```bash
-cd ~/pi_air
+cd /path/to/your/pi_air  # Navigate to your project directory
 source venv/bin/activate
 python tests/test_pms_simple.py
 ```
@@ -231,12 +239,12 @@ pi_air/
 │   └── index.html               # Web dashboard
 ├── static/
 │   └── style.css               # Dashboard styling
-├── services/
-│   ├── pimonitor.service       # System monitor service
-│   └── air-quality-monitor.service  # Air quality service
+├── systemd/
+│   ├── pimonitor.service       # System monitor service template
+│   └── air-quality-monitor.service  # Air quality service template
 ├── scripts/
 │   ├── setup_pi.sh            # Automated setup script
-│   └── install_service.sh     # Service installation
+│   └── install_service.sh     # User-agnostic service installation
 ├── tests/
 │   └── test_pms_simple.py     # Sensor tests
 ├── data/

--- a/scripts/setup_pi.sh
+++ b/scripts/setup_pi.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# Setup script for Raspberry Pi Zero 2 W
+# Setup script for Raspberry Pi (user-agnostic)
 
 echo "Setting up Pi Air Monitor on Raspberry Pi..."
+
+# Get current user's home directory
+CURRENT_USER=$(whoami)
+USER_HOME=$(eval echo ~$CURRENT_USER)
+PROJECT_NAME="pi_air"
+PROJECT_DIR="$USER_HOME/$PROJECT_NAME"
+
+echo "Setting up for user: $CURRENT_USER"
+echo "Project directory: $PROJECT_DIR"
 
 # Update system
 echo "Updating system packages..."
@@ -13,16 +22,16 @@ echo "Installing Python and system dependencies..."
 sudo apt-get install -y python3 python3-pip python3-venv git
 
 # Clone or update repository (if using git)
-if [ -d "/home/weber/pi_air" ]; then
+if [ -d "$PROJECT_DIR" ]; then
     echo "Updating existing installation..."
-    cd /home/weber/pi_air
+    cd "$PROJECT_DIR"
     git pull
 else
     echo "Cloning repository..."
-    cd /home/weber
+    cd "$USER_HOME"
     # Replace with your actual repository URL
     git clone https://github.com/andrewrweber/pi_air.git
-    cd pi_air
+    cd "$PROJECT_NAME"
 fi
 
 # Create virtual environment
@@ -35,20 +44,22 @@ source venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 
-# Copy systemd service file
-echo "Installing systemd service..."
-sudo cp services/pimonitor.service /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable pimonitor.service
+# Initialize database
+echo "Initializing database..."
+python -c "from src.database import init_database; init_database()"
 
-# Start the service
-echo "Starting Pi Monitor service..."
-sudo systemctl start pimonitor.service
+# Install systemd services using the user-agnostic script
+echo "Installing systemd services..."
+sudo chmod +x scripts/install_service.sh
+sudo ./scripts/install_service.sh
 
 # Show status
 echo "Setup complete! Service status:"
 sudo systemctl status pimonitor.service
+sudo systemctl status air-quality-monitor.service
 
 echo ""
 echo "Access the monitor at: http://$(hostname -I | awk '{print $1}'):5000"
-echo "To view logs: sudo journalctl -u pimonitor.service -f"
+echo "To view logs:"
+echo "  sudo journalctl -u pimonitor.service -f"
+echo "  sudo journalctl -u air-quality-monitor.service -f"

--- a/systemd/air-quality-monitor.service
+++ b/systemd/air-quality-monitor.service
@@ -5,11 +5,11 @@ Wants=network.target
 
 [Service]
 Type=simple
-User=weber
-Group=weber
-WorkingDirectory=/home/weber/pi_air
-Environment=PATH=/home/weber/pi_air/venv/bin
-ExecStart=/home/weber/pi_air/venv/bin/python /home/weber/pi_air/src/air_quality_monitor.py
+User={{USER}}
+Group={{GROUP}}
+WorkingDirectory={{PROJECT_DIR}}
+Environment=PATH={{PROJECT_DIR}}/venv/bin
+ExecStart={{PROJECT_DIR}}/venv/bin/python {{PROJECT_DIR}}/src/air_quality_monitor.py
 Restart=always
 RestartSec=10
 

--- a/systemd/pimonitor.service
+++ b/systemd/pimonitor.service
@@ -5,11 +5,11 @@ Wants=network.target
 
 [Service]
 Type=simple
-User=weber
-Group=weber
-WorkingDirectory=/home/weber/pi_air
-Environment=PATH=/home/weber/pi_air/venv/bin
-ExecStart=/home/weber/pi_air/venv/bin/python /home/weber/pi_air/src/app.py
+User={{USER}}
+Group={{GROUP}}
+WorkingDirectory={{PROJECT_DIR}}
+Environment=PATH={{PROJECT_DIR}}/venv/bin
+ExecStart={{PROJECT_DIR}}/venv/bin/python {{PROJECT_DIR}}/src/app.py
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
## Summary
- Resolved path issues by making systemd services work with any username and directory structure
- No more hardcoded `/home/weber/` or specific user dependencies
- Automatic detection of current user, group, and project directory paths

## Changes Made
- **Template-based service files**: Converted systemd services to use `{{USER}}`, `{{GROUP}}`, `{{PROJECT_DIR}}` placeholders
- **Enhanced install script**: Automatically detects current user, primary group, and project location
- **Improved setup script**: Works with any user directory structure, not just `/home/pi/` or `/home/weber/`
- **Updated documentation**: Reflects user-agnostic installation in CLAUDE.md and README.md
- **Better validation**: Checks for virtual environment and provides helpful error messages

## Key Features
- **Universal compatibility**: Works with any username (`pi`, `weber`, `ubuntu`, etc.)
- **Flexible paths**: Automatically detects project directory location
- **Safety checks**: Verifies virtual environment exists before installation
- **Clear feedback**: Shows detected configuration before proceeding

## Test Plan
- [ ] Test installation with different usernames (pi, weber, ubuntu, etc.)
- [ ] Verify services generate correctly with detected paths
- [ ] Confirm services start and run properly with any user configuration
- [ ] Test both quick setup and manual installation processes

## Benefits
- Eliminates path-related installation errors
- Makes the project more portable across different Pi configurations
- Reduces need for manual path corrections during setup
- Improves user experience for any Pi setup

🤖 Generated with [Claude Code](https://claude.ai/code)