### PR TITLE
Fix forecast timezone comparison bug

### DIFF
--- a/src/services/forecast_service.py
+++ b/src/services/forecast_service.py
@@ -7,7 +7,7 @@ import requests
 import sqlite3
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 from contextlib import contextmanager
 
@@ -190,7 +190,7 @@ class ForecastService:
         
         forecast_points = []
         forecast_time = datetime.utcnow().isoformat()
-        now = datetime.utcnow()
+        now = datetime.utcnow().replace(tzinfo=timezone.utc)
         
         for i, time_str in enumerate(times):
             try:


### PR DESCRIPTION
## Summary
- Fix TypeError in forecast service caused by comparing timezone-aware and timezone-naive datetime objects
- Issue was introduced in recent timezone parsing improvements that made forecast timestamps timezone-aware
- Forecast functionality was completely broken since the timezone parsing commit

## Changes
- Import `timezone` from datetime module in forecast_service.py  
- Make the `now` variable timezone-aware by adding `tzinfo=timezone.utc`
- Ensures both `forecast_dt` and `now` are timezone-aware for proper comparison

## Test plan
- [x] Tested the fix locally with Python datetime comparison
- [x] Verified forecast functionality works on Pi after applying fix
- [x] Confirmed no other timezone comparison issues in codebase

🤖 Generated with [Claude Code](https://claude.ai/code)